### PR TITLE
chore: deploy 워크플로 깃헙 토큰 변경

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Blog Deploy
 
 on:
   push:
-    branches: ['main']
+    branches: ['chore/deploy']
 
 jobs:
   build:
@@ -37,5 +37,5 @@ jobs:
       - name: Deploy GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.GH_ACTIONS_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Blog Deploy
 
 on:
   push:
-    branches: ['chore/deploy']
+    branches: ['main']
 
 jobs:
   build:


### PR DESCRIPTION
`actions-gh-pages` 에서 사용하던 토큰을 직접 발급해서 사용하고 있었는데 제거했어요.
대신 워크플로에서 기본적으로 사용 가능한 `GITHUB_TOKEN` 를 사용하도록 변경했어요.